### PR TITLE
Add check before adding host to rgm

### DIFF
--- a/tasks/create_rgm_host.yml
+++ b/tasks/create_rgm_host.yml
@@ -8,6 +8,19 @@
     validate_certs: no
   register: rgm_token
 
+- name: create_rgm_host | check rgm host
+  uri:
+    url: 'https://{{ rgm_ip }}/rgmapi/getHost'
+    method: POST
+    body:
+      token: "{{ rgm_token.json.RGMAPI_TOKEN }}"
+      hostName: "{{ ansible_nodename }}"
+      hostIp: "{{ ansible_default_ipv4['address'] }}"
+      templateHostName: "{{ d_rgm_template }}"
+    body_format: json
+    validate_certs: no
+  register: get_rgm_host_task
+
 - name: create_rgm_host | create rgm host
   uri:
     url: 'https://{{ rgm_ip }}/rgmapi/createHost'
@@ -20,6 +33,7 @@
       exportConfiguration: true
     body_format: json
     validate_certs: no
+  when: get_rgm_host_task.json.result is not mapping
 
 - name: create_rgm_host | export configuration
   uri:
@@ -31,3 +45,4 @@
     body_format: json
     status_code: 200
     validate_certs: no
+  when: get_rgm_host_task.json.result is not mapping


### PR DESCRIPTION
Removed previous when clauses causing a skip if metricbeat was already installed, even if host wasn't in RGM. 

Added a call on RGM to check if host was present, and altered the previous when clauses to add the host if the host isn't found. 